### PR TITLE
Use new nodes.json url

### DIFF
--- a/resolve.py
+++ b/resolve.py
@@ -10,7 +10,7 @@ import dateutil.parser
 import ipaddress
 import urllib.request
 
-upstream = 'https://harvester.ffh.zone/nodes.json'
+upstream = 'https://harvester.ffh.zone/api/nodes.json'
 tmp_file = '/tmp/nodes.json'
 
 


### PR DESCRIPTION
The old url target got removed,
`https://harvester.ffh.zone/api/nodes.json` is recommended.